### PR TITLE
MAX-5331 React UI cannot be rendered via index.html

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -286,6 +286,7 @@ module.exports = {
     new InterpolateHtmlPlugin(env.raw),
     // Generates an `index.html` file with the <script> injected.
     new HtmlWebpackPlugin({
+      template: paths.appHtml,
       inject: !containUIComponents,
       containUIComponents: containUIComponents,
       minify: {

--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -10,6 +10,9 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <% if (htmlWebpackPlugin.options.containUIComponents) { %>
+      <link href="<%=htmlWebpackPlugin.files.css[0]%>" rel="stylesheet">
+    <% } %>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -56,8 +59,8 @@
         }, false);
       })();
     </script>
-    <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
-    <link rel="import" href="/bower_components/px-theme/px-theme-styles.html">
+    <script src="%PUBLIC_URL%/bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+    <link rel="import" href="%PUBLIC_URL%/bower_components/px-theme/px-theme-styles.html">
     <style include="px-theme-styles" is="custom-style"></style>
     <% } %>
   </body>


### PR DESCRIPTION
The root cause of this issue is that we missed the index html template in product config file. Just added.

And we also need to manually add css import when use containUIComponents case.

@joshsylvester @shinxi , please help review.