### PR TITLE
MAX-5734 NewUI: Neocore-React-UI-TPR still green when UT failed

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -43,7 +43,9 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '^.+\\.css$': resolve('config/jest/cssTransform.js'),
       '^(?!.*\\.(js|jsx|css|json)$)': resolve('config/jest/fileTransform.js'),
     },
-    transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
+    transformIgnorePatterns: [
+      '[/\\\\]node_modules[/\\\\](?!@svmx[/\\\\]ui-components-predix).+\\.(js|jsx)$',
+    ],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
     },


### PR DESCRIPTION
Since we publish *ui-components-predix* as untranspiled, so we need to transform it before running jest. Just remove `@svmx/ui-components-predix` from transformIgnorePatterns list.

@joshsylvester @shinxi , please help review.