### PR TITLE
MAX-5899 NewUI Component: Support Percent Datatype Component

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -36,8 +36,8 @@ const env = getClientEnvironment(publicUrl);
 
 const uiLibBowerPath = 'node_modules/@svmx/ui-components-predix/bower_components';
 let jsIncludePaths = [paths.appSrc];
-let resolveModules = ['bower_components', 'node_modules', paths.appNodeModules];
-let sassIncludePaths = ['bower_components', 'node_modules', 'src'];
+let resolveModules = ['node_modules', paths.appNodeModules, 'bower_components'];
+let sassIncludePaths = ['node_modules', 'src', 'bower_components'];
 
 const containUIComponents = fs.existsSync(path.resolve(paths.appPath, uiLibBowerPath));
 
@@ -83,16 +83,16 @@ if (containUIComponents) {
     path.resolve(paths.appNodeModules, '@svmx/ui-components-predix/lib'),
   ];
   resolveModules = [
-    'bower_components',
-    uiLibBowerPath,
     'node_modules',
     paths.appNodeModules,
-  ];
-  sassIncludePaths = [
     'bower_components',
     uiLibBowerPath,
+  ];
+  sassIncludePaths = [
     'node_modules',
     'src',
+    'bower_components',
+    uiLibBowerPath,
   ];
   plugins.push(
     new CopyWebpackPlugin([

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -43,8 +43,8 @@ const env = getClientEnvironment(publicUrl);
 const uiLibBowerPath = 'node_modules/@svmx/ui-components-predix/bower_components';
 const uiLibBuiltBowerPath = 'node_modules/@svmx/ui-components-predix/build/bower_components';
 let jsIncludePaths = [paths.appSrc];
-let resolveModules = ['bower_components', 'node_modules', paths.appNodeModules];
-let sassIncludePaths = ['bower_components', 'node_modules', 'src'];
+let resolveModules = ['node_modules', paths.appNodeModules, 'bower_components'];
+let sassIncludePaths = ['node_modules', 'src', 'bower_components'];
 
 const containUIComponents = fs.existsSync(path.resolve(paths.appPath, uiLibBowerPath));
 
@@ -168,8 +168,8 @@ if (containUIComponents) {
     paths.appSrc,
     path.resolve(paths.appNodeModules, '@svmx/ui-components-predix/lib'),
   ];
-  resolveModules = ['bower_components', uiLibBowerPath, 'node_modules', paths.appNodeModules];
-  sassIncludePaths = ['bower_components', uiLibBowerPath, 'node_modules', 'src'];
+  resolveModules = ['node_modules', paths.appNodeModules, 'bower_components', uiLibBowerPath];
+  sassIncludePaths = ['node_modules', 'src', 'bower_components', uiLibBowerPath];
   plugins.push(
     new CopyWebpackPlugin([
       {


### PR DESCRIPTION
* When integrating react-intl, it unexpected finds react-intl's related dependencies at bower_components, so just lower the priority of bower_components at resolveModules/sassIncludePaths to fix the issue.

@joshsylvester pls help review.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
