### PR TITLE
UI-1015 minor update to webpack to handle sass files from lightning.

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -91,6 +91,7 @@ const plugins = [
 if (containsUILightningLibrary) {
   sassIncludePaths.push(
     path.resolve(uiLightningPath, 'node_modules'),
+    uiLightningPath
   );
   plugins.push(
     new CopyWebpackPlugin([
@@ -129,7 +130,7 @@ const jsIncludePaths = libs.reduce(
     });
     return result;
   },
-  [paths.appSrc],
+  [paths.appSrc]
 );
 
 

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -182,6 +182,7 @@ const plugins = [
 if (containsUILightningLibrary) {
   sassIncludePaths.push(
     path.resolve(uiLightningPath, 'node_modules'),
+    uiLightningPath
   );
 }
 
@@ -211,7 +212,7 @@ const jsIncludePaths = libs.reduce(
     });
     return result;
   },
-  [paths.appSrc],
+  [paths.appSrc]
 );
 
 // This is the production configuration.


### PR DESCRIPTION
we're loading sass files from the root via import like this:

```
@import 'lib/package';

.blue {
  color: $salesforce-blue;
}
```

but cra's setup wasn't setup for that (it was setup correctly for predix, but not lightning)