### PR TITLE
UI-1145 Add src to resolve modules

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -44,7 +44,7 @@ const containsUIPredixLibrary = fs.existsSync( uiPredixPath);
 const containsUILightningLibrary = fs.existsSync(uiLightningPath);
 const containsUIComponents = (containsUIPredixLibrary || containsUILightningLibrary);
 
-let resolveModules = ['node_modules', appNodeModules];
+let resolveModules = ['node_modules', 'src', appNodeModules];
 let sassIncludePaths = ['node_modules', 'src'];
 
 const plugins = [

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -52,7 +52,7 @@ const containsUIComponents = (containsUIPredixLibrary || containsUILightningLibr
 
 
 
-let resolveModules = ['node_modules', appNodeModules];
+let resolveModules = ['node_modules', 'src', appNodeModules];
 let sassIncludePaths = ['node_modules', 'src'];
 
 // Assert this just to be safe.


### PR DESCRIPTION
Base on the discussion between Mallik and me, all application using our `create-react-app` should have `src` directory. Thus I added `src` to the resolve modules so that developers can access sub-directories under `src` using absolute path. For example:
```js
import SomeModule from 'some-module'; // Full path: '/project-root/src/some-module'
```
