### PR TITLE
UI-2199 loosen stylelint rules for rule-empty-line-before rules

### DIFF
--- a/packages/react-scripts/template/.stylelintrc
+++ b/packages/react-scripts/template/.stylelintrc
@@ -4,8 +4,16 @@
     "selector-class-pattern": "^([\\.\\%]?[a-zA-Z]*[-]?[a-z0-9\\-]*)(\\.[a-z0-9\\-]*)?(__[a-z0-9]*[-]?[a-z0-9\\-]*)?(--[a-z0-9]*[-]?[a-z0-9\\-]*)?(\\:[a-z]*)*$",
     "selector-id-pattern": "^([\\.\\%]?[a-z]*[-]?[a-z0-9\\-]*)(\\.[a-z0-9\\-]*)?(__[a-z0-9]*[-]?[a-z0-9\\-]*)?(--[a-z0-9]*[-]?[a-z0-9\\-]*)?(\\:[a-z]*)*$",
     "selector-type-no-unknown": [true, {"ignore": ["custom-elements"]}],
-    "at-rule-empty-line-before": "always",
-    "rule-empty-line-before": "always",
+    "at-rule-empty-line-before": ["always",
+      {
+        except: ["after-same-name", "inside-block", "first-nested"],
+        ignore: ["after-comment"]
+      }],
+    "rule-empty-line-before": ["always",
+      {
+        except: ["after-single-line-comment", "first-nested"],
+        ignore: ["after-comment"]
+      }],
     "at-rule-no-unknown": null,
     "property-no-vendor-prefix": null,
     "max-nesting-depth": 1,


### PR DESCRIPTION
* updated template configuration for `rule-empty-line-before` and `at-rule-empty-line-before` to allow things like nesting and comments before the rule to not trigger a warning.
