### PR TITLE
UI-2785 webpack dev config update for slds assets

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -38,6 +38,7 @@ const env = getClientEnvironment(publicUrl);
 // Get possible module paths
 const appNodeModules = paths.appNodeModules;
 const uiLightningPath = path.resolve(appNodeModules, '@svmx/ui-components-lightning');
+const uiLightningNodeModulesPath = path.resolve(uiLightningPath, 'node_modules');
 const uiPredixPath = path.resolve(appNodeModules, '@svmx/ui-components-predix');
 const uiLibBowerPath = path.resolve(uiPredixPath, 'bower_components');
 const uiLibBuiltBowerPath = path.resolve(uiPredixPath, 'build/polymer');
@@ -99,7 +100,7 @@ if (containsUILightningLibrary) {
   plugins.push(
     new CopyWebpackPlugin([
       {
-        context: path.resolve(appNodeModules, '@salesforce-ux/design-system/assets'),
+        context: path.resolve(uiLightningNodeModulesPath, '@salesforce-ux/design-system/assets'),
         from: '**/*',
         to: 'assets',
       },


### PR DESCRIPTION
- minor change to webpack config to allow SLDS assets to copy properly when local


#### There are 4 related PR's for this same change:
- *ui-lightning*: [#402](https://github.com/ServiceMax-Engineering/ui-components-lightning/pull/402) RadioGroup propType fixes
- *ui-lightning*: [#404](https://github.com/ServiceMax-Engineering/ui-components-lightning/pull/404) Misc component propType fixes
- *ui-lightning-demo*: [#32](https://github.com/ServiceMax-Engineering/ui-components-lightning-demo/pull/32) Added RadioWrapper demo & stop console errors.
- *create-react-app*: [#46](https://github.com/ServiceMax-Engineering/create-react-app/pull/46/files) minor update to dev webpack for lightning assets