### PR TITLE
UI-2735 Webpack config changes to enable custom icons.

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -269,6 +269,11 @@ module.exports = {
               name: 'static/media/[name].[hash:8].[ext]',
             },
           },
+          // Add the raw loader for custom ServiceMax SVG assets loaded through React
+          {
+            test: [/\.svg$/],
+            loader: require.resolve('raw-loader'),
+          },
           // Process JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -334,6 +334,11 @@ module.exports = {
               name: 'static/media/[name].[hash:8].[ext]',
             },
           },
+          // Add the raw loader for custom ServiceMax SVG assets loaded through React
+          {
+            test: [/\.svg$/],
+            loader: require.resolve('raw-loader'),
+          },
           // Process JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,


### PR DESCRIPTION
- minor changes to webpack configurations to ensure that local and production can still load custom icons.
- at this time, _ui-components-predix_ does not use any custom svg assets, and this change should not affect projects using the predix library.

Related [PR on ui-components-lightning](https://github.com/ServiceMax-Engineering/ui-components-lightning/pull/439) that adds support for custom icons