### PR TITLE
MAX-11773 Add config for proxy setup and split chunks

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -30,8 +30,7 @@ function ensureSlash(path, needsSlash) {
   }
 }
 
-const getPublicUrl = appPackageJson =>
-  envPublicUrl || require(appPackageJson).homepage;
+const getPublicUrl = appPackageJson => envPublicUrl || require(appPackageJson).homepage;
 
 // We use `PUBLIC_URL` environment variable or "homepage" field to infer
 // "public path" at which the app is served.
@@ -41,8 +40,7 @@ const getPublicUrl = appPackageJson =>
 // like /todos/42/static/js/bundle.7289d.js. We have to know the root.
 function getServedPath(appPackageJson) {
   const publicUrl = getPublicUrl(appPackageJson);
-  const servedUrl =
-    envPublicUrl || (publicUrl ? url.parse(publicUrl).pathname : '/');
+  const servedUrl = envPublicUrl || (publicUrl ? url.parse(publicUrl).pathname : '/');
   return ensureSlash(servedUrl, true);
 }
 
@@ -57,6 +55,7 @@ module.exports = {
   appSrc: resolveApp('src'),
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveApp('src/test/jest-setup.js'),
+  proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
@@ -77,6 +76,7 @@ module.exports = {
   appSrc: resolveApp('src'),
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveApp('src/test/jest-setup.js'),
+  proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
@@ -88,8 +88,7 @@ module.exports = {
 const ownPackageJson = require('../package.json');
 const reactScriptsPath = resolveApp(`node_modules/${ownPackageJson.name}`);
 const reactScriptsLinked =
-  fs.existsSync(reactScriptsPath) &&
-  fs.lstatSync(reactScriptsPath).isSymbolicLink();
+  fs.existsSync(reactScriptsPath) && fs.lstatSync(reactScriptsPath).isSymbolicLink();
 
 // config before publish: we're in ./packages/react-scripts/config/
 if (
@@ -107,6 +106,7 @@ if (
     appSrc: resolveOwn('template/src'),
     yarnLockFile: resolveOwn('template/yarn.lock'),
     testsSetup: resolveOwn('template/src/test/jest-setup.js'),
+    proxySetup: resolveOwn('template/src/setupProxy.js'),
     appNodeModules: resolveOwn('node_modules'),
     publicUrl: getPublicUrl(resolveOwn('package.json')),
     servedPath: getServedPath(resolveOwn('package.json')),

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -28,6 +28,12 @@ const paths = require('./paths');
 const getClientEnvironment = require('./env');
 const libs = require('./libs');
 
+// should we enable split chunking or not
+const shouldUseSplitChunks = process.env.ENABLE_SPLIT_CHUNKS !== 'false';
+
+// should we enable runtime chunking
+const shouldUseRuntimeChunk = process.env.GENERATE_RUNTIME_CHUNK !== 'false';
+
 // should we inline the runtime chunking process
 const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 
@@ -84,6 +90,19 @@ if (containsUILightningLibrary) {
   cssFilename = 'static/css/[name].css';
   jsFilename = 'static/js/[name].js';
 }
+
+// Use this option to disable split chunks
+const disableSplitChunks = {
+  cacheGroups: {
+    default: false,
+  },
+};
+
+// Use this as default option for split chunks
+const defaultSplitChunks = {
+  chunks: 'all',
+  name: false,
+};
 
 const plugins = [
   // Inlines the webpack runtime script. This script is too small to warrant
@@ -305,13 +324,10 @@ module.exports = {
     // Automatically split vendor and commons
     // https://twitter.com/wSokra/status/969633336732905474
     // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-    splitChunks: {
-      chunks: 'all',
-      name: false,
-    },
+    splitChunks: shouldUseSplitChunks ? defaultSplitChunks : disableSplitChunks,
     // Keep the runtime chunk seperated to enable long term caching
     // https://twitter.com/wSokra/status/969679223278505985
-    runtimeChunk: true,
+    runtimeChunk: shouldUseRuntimeChunk,
   },
   resolve: {
     symlinks: false,

--- a/packages/react-scripts/config/webpack.config.staging.js
+++ b/packages/react-scripts/config/webpack.config.staging.js
@@ -28,6 +28,12 @@ const paths = require('./paths');
 const getClientEnvironment = require('./env');
 const libs = require('./libs');
 
+// should we enable split chunking or not
+const shouldUseSplitChunks = process.env.ENABLE_SPLIT_CHUNKS !== 'false';
+
+// should we enable runtime chunking
+const shouldUseRuntimeChunk = process.env.GENERATE_RUNTIME_CHUNK !== 'false';
+
 // should we inline the runtime chunking process
 const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 
@@ -84,6 +90,19 @@ if (containsUILightningLibrary) {
   cssFilename = 'static/css/[name].css';
   jsFilename = 'static/js/[name].js';
 }
+
+// Use this option to disable split chunks
+const disableSplitChunks = {
+  cacheGroups: {
+    default: false,
+  },
+};
+
+// Use this as default option for split chunks
+const defaultSplitChunks = {
+  chunks: 'all',
+  name: false,
+};
 
 const plugins = [
   // Inlines the webpack runtime script. This script is too small to warrant
@@ -314,13 +333,10 @@ module.exports = {
     // Automatically split vendor and commons
     // https://twitter.com/wSokra/status/969633336732905474
     // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-    splitChunks: {
-      chunks: 'all',
-      name: false,
-    },
+    splitChunks: shouldUseSplitChunks ? defaultSplitChunks : disableSplitChunks,
     // Keep the runtime chunk seperated to enable long term caching
     // https://twitter.com/wSokra/status/969679223278505985
-    runtimeChunk: true,
+    runtimeChunk: shouldUseRuntimeChunk,
   },
   resolve: {
     symlinks: false,

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -13,6 +13,7 @@ const noopServiceWorkerMiddleware = require('react-dev-utils/noopServiceWorkerMi
 const ignoredFiles = require('react-dev-utils/ignoredFiles');
 const config = require('./webpack.config.dev');
 const paths = require('./paths');
+const fs = require('fs');
 
 const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
 const host = process.env.HOST || '0.0.0.0';
@@ -90,6 +91,13 @@ module.exports = function(proxy, allowedHost) {
     public: allowedHost,
     proxy,
     before(app) {
+      // Support proxy setup for dev environment
+      if (fs.existsSync(paths.proxySetup)) {
+        // This registers user provided middleware for proxy reasons
+        require(paths.proxySetup)(app);
+      }
+
+
       // This lets us open files from the runtime error overlay.
       app.use(errorOverlayMiddleware());
       // This service worker file is effectively a 'no-op' that will reset any


### PR DESCRIPTION
Our latest react-scripts can't work well on app. Add config for proxy setup and split chunks to fix the issues.
**Proxy setup:**
Added proxy setup to `webpackDevServer.config.js`

See more
- Proxying API Requests in Development
https://facebook.github.io/create-react-app/docs/proxying-api-requests-in-development
- see section:  Move advanced proxy configuration to src/setupProxy.js
https://github.com/facebook/create-react-app/issues/5103#issue-364148526

**Split chunks**
Added `ENABLE_SPLIT_CHUNKS` and `GENERATE_RUNTIME_CHUNK` to allow disable split/runtime chunks based on app needs.
