### PR TITLE
MAX-13475 SB: Kabob icon is not shown on gantt chart in latest build

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -268,21 +268,24 @@ module.exports = {
         // match the requirements. When no loader matches it will fall
         // back to the "file" loader at the end of the loader list.
         oneOf: [
+          // Add the raw loader for custom ServiceMax SVG assets loaded through React
+          {
+            test: [/\.svg$/],
+            issuer: {
+              test: /\.jsx?$/,
+            },
+            loader: require.resolve('raw-loader'),
+          },
           // "url" loader works like "file" loader except that it embeds assets
           // smaller than specified limit in bytes as data URLs to avoid requests.
           // A missing `test` is equivalent to a match.
           {
-            test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
+            test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/, /\.svg$/],
             loader: require.resolve('url-loader'),
             options: {
               limit: 10000,
               name: 'static/media/[name].[hash:8].[ext]',
             },
-          },
-          // Add the raw loader for custom ServiceMax SVG assets loaded through React
-          {
-            test: [/\.svg$/],
-            loader: require.resolve('raw-loader'),
           },
           // Process JS with Babel.
           {


### PR DESCRIPTION
* Add support to be able to load svg in both React and SCSS, via two different configurations. Use raw-loader if svg is loaded inside React component, otherwise use url-loader.

@joshsylvester @elvinfucom @benjaminliugang pls help review.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
