### PR TITLE
MAX-14222 Use setupFilesAfterEnv instead of setupTestFrameworkScriptFile

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -14,13 +14,15 @@ const paths = require('../../config/paths');
 const libs = require('../../config/libs');
 const appNodeModules = paths.appNodeModules;
 
-const transformIgnorePaths = libs.reduce((result, lib)=> {
-  const jsPath = path.resolve(appNodeModules, lib.name)
-  if (fs.existsSync(jsPath)) {
-    result.push(lib.name);
-  }
-  return result;
-}, []).join("|");
+const transformIgnorePaths = libs
+  .reduce((result, lib) => {
+    const jsPath = path.resolve(appNodeModules, lib.name);
+    if (fs.existsSync(jsPath)) {
+      result.push(lib.name);
+    }
+    return result;
+  }, [])
+  .join('|');
 
 module.exports = (resolve, rootDir, isEjecting) => {
   // Use this instead of `paths.testsSetup` to avoid putting
@@ -34,13 +36,13 @@ module.exports = (resolve, rootDir, isEjecting) => {
   const config = {
     collectCoverageFrom: [
       'src/**/*.{js,jsx,mjs}',
-      "!src/**/index.js",
-      "!src/registerServiceWorker.js",
-      "!src/node/*.js",
-      "!src/test/*.js"
+      '!src/**/index.js',
+      '!src/registerServiceWorker.js',
+      '!src/node/*.js',
+      '!src/test/*.js',
     ],
     setupFiles: [resolve('config/polyfills.js')],
-    setupTestFrameworkScriptFile: setupTestsFile,
+    setupFilesAfterEnv: [setupTestsFile],
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}',
       '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}',

--- a/packages/react-scripts/template/README-fb.md
+++ b/packages/react-scripts/template/README-fb.md
@@ -1459,12 +1459,12 @@ const localStorageMock = {
 global.localStorage = localStorageMock
 ```
 
->Note: Keep in mind that if you decide to "eject" before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupTestFrameworkScriptFile` in the configuration for Jest, something like the following:
+>Note: Keep in mind that if you decide to "eject" before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupFilesAfterEnv` in the configuration for Jest, something like the following:
 
 >```js
 >"jest": {
 >   // ...
->   "setupTestFrameworkScriptFile": "<rootDir>/src/setupTests.js"
+>   "setupFilesAfterEnv": ["<rootDir>/src/setupTests.js"]
 >  }
 >  ```
 


### PR DESCRIPTION
Since `setupTestFrameworkScriptFile` already deprecated in `jest@24.0.0`, just update as `setupFilesAfterEnv`.

@elvinfucom @vincentcn @shinxi , please help review.
