### PR TITLE
MAX-24208 Upgrade react-redux, react-router and other 3rd libraries

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -83,11 +83,19 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'coverageReporters',
     'coverageThreshold',
     'snapshotSerializers',
+    'moduleNameMapper',
   ];
   if (overrides) {
     supportedKeys.forEach(key => {
-      if (overrides.hasOwnProperty(key)) {
-        config[key] = overrides[key];
+      if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+        if (Array.isArray(config[key]) || typeof config[key] !== 'object') {
+          // for arrays or primitive types, directly override the config key
+          config[key] = overrides[key];
+        } else {
+          // for object types, extend gracefully
+          config[key] = Object.assign({}, config[key], overrides[key]);
+        }
+
         delete overrides[key];
       }
     });


### PR DESCRIPTION
* To let the latest react-redux work (multiple react version issue - https://react-redux.js.org/troubleshooting#could-not-find-store-in-either-the-context-or-props) at jest, support moduleNameMapper and extend gracefully for object types (the code changes comes from the facebook/cra directly).

@elvinfucom @benjaminliugang @haoruiqian pls help review.